### PR TITLE
Fix potential memory leak

### DIFF
--- a/Chatto/Source/ChatController/BaseChatViewController+Changes.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController+Changes.swift
@@ -49,13 +49,14 @@ extension BaseChatViewController {
         }
 
         self.updateQueue.addTask({ [weak self] (runNextTask) -> Void in
-            guard let sSelf = self else { return }
+            guard let self else { return }
 
-            let oldItems = sSelf.chatItemCompanionCollection
-            sSelf.updateModels(newItems: newItems, oldItems: oldItems, updateType: updateType, completion: {
-                guard let sSelf = self else { return }
-                if sSelf.updateQueue.isEmpty {
-                    sSelf.enqueueMessageCountReductionIfNeeded()
+            let oldItems = self.chatItemCompanionCollection
+            self.updateModels(newItems: newItems, oldItems: oldItems, updateType: updateType, completion: {
+                [weak self] in
+                guard let self else { return }
+                if self.updateQueue.isEmpty {
+                    self.enqueueMessageCountReductionIfNeeded()
                 }
                 completion?()
                 DispatchQueue.main.async(execute: { () -> Void in
@@ -266,8 +267,8 @@ extension BaseChatViewController {
             })
         }
 
-        let createModelUpdate = {
-            return self.createModelUpdates(
+        let createModelUpdate = { [weak self] in
+            return self?.createModelUpdates(
                 newItems: newItems,
                 oldItems: oldItems,
                 collectionViewWidth: collectionViewWidth)
@@ -275,13 +276,13 @@ extension BaseChatViewController {
 
         if performInBackground {
             DispatchQueue.global(qos: .userInitiated).async { () -> Void in
-                let modelUpdate = createModelUpdate()
+                guard let modelUpdate = createModelUpdate() else { return }
                 DispatchQueue.main.async(execute: { () -> Void in
                     perfomBatchUpdates(modelUpdate.changes, modelUpdate.updateModelClosure)
                 })
             }
         } else {
-            let modelUpdate = createModelUpdate()
+            guard let modelUpdate = createModelUpdate() else { return }
             perfomBatchUpdates(modelUpdate.changes, modelUpdate.updateModelClosure)
         }
     }


### PR DESCRIPTION
Welcome to the dark side..
top 2 crashes in Wallapop are coming from chat, and you know now who owns this beautiful thing
 
![image](https://github.com/Wallapop/Chatto/assets/2325884/0d110d51-40c2-4397-baf6-1e4a511b2895)
![image](https://github.com/Wallapop/Chatto/assets/2325884/9a1d66ad-39a3-4b88-9ed3-b454c67b902a)

and because i don't have a lot of things to do in my free time, i decided to take a look, the thing i found that there're a lot a strong reference taken from self inside closuers in one of the functions from crashStack, which in theory might cause this error:
`EXC_BAD_ACCESS KERN_INVALID_ADDRESS 0x0000000000000000` 

to verify my finding, i checked the current updated version of Chatto, and i found that these leaks are fixed in the same places i was looking at
![image](https://github.com/Wallapop/Chatto/assets/2325884/9347c686-4846-44f9-af85-536df35a43cc)

so i really think that after merging this pr we will reduce the crashes