### PR TITLE
Move newItem to inside the closure

### DIFF
--- a/Chatto/Source/ChatController/BaseChatViewController+Changes.swift
+++ b/Chatto/Source/ChatController/BaseChatViewController+Changes.swift
@@ -42,8 +42,6 @@ private struct HashableItem: Hashable {
 extension BaseChatViewController {
 
     public func enqueueModelUpdate(updateType: UpdateType, completion: (() -> Void)? = nil) {
-        let newItems = self.chatDataSource?.chatItems ?? []
-
         if self.updatesConfig.coalesceUpdates {
             self.updateQueue.flushQueue()
         }
@@ -52,6 +50,7 @@ extension BaseChatViewController {
             guard let self else { return }
 
             let oldItems = self.chatItemCompanionCollection
+            let newItems = self.chatDataSource?.chatItems ?? []
             self.updateModels(newItems: newItems, oldItems: oldItems, updateType: updateType, completion: {
                 [weak self] in
                 guard let self else { return }


### PR DESCRIPTION
<img width="894" alt="image" src="https://github.com/Wallapop/Chatto/assets/2325884/1e436177-11d8-4b47-9790-a01273b8fc5b">
we were capturing newItems inside the closure, which was capturing self, i don't know.. but feels like a bug 


could fix this: 
https://wallapop.atlassian.net/browse/WPA-49481
or/and
https://wallapop.atlassian.net/browse/WPA-49489
